### PR TITLE
Small improvements to sharp's usage within these tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ var sleep = require('sleep');
 var os = require("os");
 var cpus = os.cpus();
 
+// Ensure sharp is required before canvas - https://github.com/lovell/sharp/issues/371
+require('sharp');
+
 // Prepare list of images
 var pathSource = process.argv[2] + '/';
 var pathResult = process.argv[3] + '/';

--- a/modules/sharp-simd.js
+++ b/modules/sharp-simd.js
@@ -3,8 +3,8 @@
 var sharp = require('sharp');
 
 exports.process = function (fullImagePath, fullImagePathResult, size, callback) {
-  // Disable experimental SIMD support - this is the default behaviour
-  sharp.simd(false);
+  // Enable experimental SIMD support
+  sharp.simd(true);
 
   sharp(fullImagePath)
     .resize(size[0], size[1])

--- a/test/modules.js
+++ b/test/modules.js
@@ -3,6 +3,9 @@ var config = require('config');
 var fs = require('fs');
 var staticPath = './test/static/';
 
+// Ensure sharp is required before canvas - https://github.com/lovell/sharp/issues/371
+require('sharp');
+
 describe('Check modules', function () {
 
   var modulesPath = require("path").join(__dirname, '../', config.get('modulesPath'));


### PR DESCRIPTION
Hello, thanks for creating this perf benchmark for Node.js image processing and including sharp (libvips maintainer @jcupitt alerted me to the presence of this repo).

This PR makes a few small improvements:
- Ensure `sharp` is required before `canvas` to avoid glib version clash. https://github.com/lovell/sharp/issues/371
- As sharp's default `resize()` behaviour is to crop, we can remove the metadata+extract step. This is more for code simplification rather than providing any performance benefit as those operations are very cheap.
- Add test case for sharp with SIMD (via liborc) feature enabled.

Here are the results I see locally when run on an i3-4170 CPU:

```
== START ==
canvas.js : 4.586 img/sec; done in 21.806656 sec; minCPUidle: 93%; minFreeMem: 5065Mb; MaxLoadAvg: 0.34
gm-imagemagic.js : 3.395 img/sec; done in 29.454461 sec; minCPUidle: 93%; minFreeMem: 5155Mb; MaxLoadAvg: 0.79
gm.js : 3.403 img/sec; done in 29.387891 sec; minCPUidle: 93%; minFreeMem: 5269Mb; MaxLoadAvg: 0.94
lwip.js : 1.61 img/sec; done in 62.099024 sec; minCPUidle: 93%; minFreeMem: 4733Mb; MaxLoadAvg: 0.68
sharp-simd.js : 10.507 img/sec; done in 9.517774 sec; minCPUidle: 93%; minFreeMem: 4951Mb; MaxLoadAvg: 0.75
sharp.js : 10.477 img/sec; done in 9.544731 sec; minCPUidle: 93%; minFreeMem: 4981Mb; MaxLoadAvg: 0.85
== DONE ==
```
